### PR TITLE
fixed activity filename

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func export(activities []api.Activity, exp func(io.Writer) exporter, ext string)
 	defer checkedClose(zw, &err)
 
 	for _, activity := range activities {
-		filename := fmt.Sprintf("Runtastic %s %s.%s", formatTime(activity.EndTime), activity.Type, ext)
+		filename := fmt.Sprintf("Runtastic %s %s.%s", formatTime(activity.EndTime), activity.Type.DisplayName, ext)
 
 		header := zip.FileHeader{
 			Name:   filename,


### PR DESCRIPTION
This change sets the last part of the filename from an activity to the DisplayName of an activityType instead of the complete activityType object.