### PR TITLE
"laterThan" parameter

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ const usage = `Usage of Runtastic Archiver:
   -format string
     	Output format (gpx or tcx)
   -laterThan string
-    	Archives only activities after the specified date`
+    	Archives only activities after the specified date (in RFC3339 format)`
 
 var (
 	email     = flag.String("email", "", "")

--- a/main.go
+++ b/main.go
@@ -23,12 +23,15 @@ const usage = `Usage of Runtastic Archiver:
   -password string
     	Password (required)
   -format string
-    	Output format (gpx or tcx)`
+    	Output format (gpx or tcx)
+  -laterThan string
+    	Archives only activities after the specified date`
 
 var (
 	email     = flag.String("email", "", "")
 	password  = flag.String("password", "", "")
 	format    = flag.String("format", "gpx", "")
+	laterThan = flag.String("laterThan", "", "")
 	tolerance = flag.Int("tolerance", 15, "")
 
 	errMissingCredentials = errors.New("Missing email address or password")
@@ -139,7 +142,15 @@ func main() {
 	}
 
 	session.Options.Tolerance = *tolerance
-	activities, err := session.GetActivities(ctx)
+	syncedUntil := int64(0)
+	if *laterThan != "" {
+		laterThanDate, err := time.Parse(time.RFC3339, *laterThan)
+		if err != nil {
+			glog.Exit(err)
+		}
+		syncedUntil = laterThanDate.Unix()
+	}
+	activities, err := session.GetActivities(ctx, syncedUntil)
 
 	if err != nil {
 		glog.Exit(err)


### PR DESCRIPTION
Hi,

I've added "laterThan" parameter that allows the tool to be used for incremental backups/synchronizations. I'm using the tool as a part of my RuntasticToSTRAVA sync script and downloading everything every time was a bit excessive. Technically I don't need the packing to zip either, but this will do. :-)

I'm not a Go coder, so if you think it's a good addition, but want to do something differently, tell me.

Overall, nice tool. :-) Regards.